### PR TITLE
Add support for STARTTLS and SSL

### DIFF
--- a/source/SMTPtool/Forms/Main.Designer.cs
+++ b/source/SMTPtool/Forms/Main.Designer.cs
@@ -111,6 +111,8 @@ namespace SMTPtool
             this.statusLabelLink = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolTipUpdateStatus = new System.Windows.Forms.ToolStripStatusLabel();
             this.txtSessionEhlo = new System.Windows.Forms.TextBox();
+            this.chbStartTLS = new System.Windows.Forms.CheckBox();
+            this.chbSSL = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.nrcCount)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -334,6 +336,8 @@ namespace SMTPtool
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.chbSSL);
+            this.groupBox2.Controls.Add(this.chbStartTLS);
             this.groupBox2.Controls.Add(this.chbSaveInOutbox);
             this.groupBox2.Controls.Add(this.btnDelAttachmentAll);
             this.groupBox2.Controls.Add(this.cbxTo);
@@ -984,6 +988,26 @@ namespace SMTPtool
             this.txtSessionEhlo.TabIndex = 37;
             this.txtSessionEhlo.Text = "servername";
             // 
+            // chbStartTLS
+            // 
+            this.chbStartTLS.AutoSize = true;
+            this.chbStartTLS.Location = new System.Drawing.Point(466, 81);
+            this.chbStartTLS.Name = "chbStartTLS";
+            this.chbStartTLS.Size = new System.Drawing.Size(99, 17);
+            this.chbStartTLS.TabIndex = 30;
+            this.chbStartTLS.Text = "Enable STARTTLS";
+            this.chbStartTLS.UseVisualStyleBackColor = true;
+            // 
+            // chbSSL
+            // 
+            this.chbSSL.AutoSize = true;
+            this.chbSSL.Location = new System.Drawing.Point(466, 104);
+            this.chbSSL.Name = "chbSSL";
+            this.chbSSL.Size = new System.Drawing.Size(99, 17);
+            this.chbSSL.TabIndex = 31;
+            this.chbSSL.Text = "Enable SSL";
+            this.chbSSL.UseVisualStyleBackColor = true;
+            // 
             // Main
             // 
             this.AllowDrop = true;
@@ -1110,8 +1134,9 @@ namespace SMTPtool
         public Button btnSessionQuit;
         public Label lblRemailSize;
         public TextBox txtSessionEhlo;
+        public CheckBox chbStartTLS;
+        public CheckBox chbSSL;
 
         public System.EventHandler treeViewExpanded { get; set; }
     }
 }
-

--- a/source/SMTPtool/Forms/Main.cs
+++ b/source/SMTPtool/Forms/Main.cs
@@ -19,6 +19,7 @@ using SMTPtool.helper;
 using SMTPtestTool;
 using System.Drawing;
 using System.Net.Http;
+using MailKit.Security;
 
 
 namespace SMTPtool
@@ -508,7 +509,21 @@ namespace SMTPtool
             }
         }
 
+        private void btnSend_Click(object sender, EventArgs e)
+        {
+            SecureSocketOptions secureSocketOptions = SecureSocketOptions.None;
 
+            if (chbStartTLS.Checked)
+            {
+                secureSocketOptions = SecureSocketOptions.StartTls;
+            }
+            else if (chbSSL.Checked)
+            {
+                secureSocketOptions = SecureSocketOptions.SslOnConnect;
+            }
+
+            mailTab.btnSendClicked(secureSocketOptions);
+        }
            
     }
 }

--- a/source/SMTPtool/MailTab/SMTPsender.cs
+++ b/source/SMTPtool/MailTab/SMTPsender.cs
@@ -12,6 +12,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Net.Security;
 using MailKit.Net.Smtp;
 using MimeKit;
+using MailKit.Security;
 
 namespace SMTPtool
 {
@@ -24,11 +25,11 @@ namespace SMTPtool
 
         List<MimeMessage> mailList = new List<MimeMessage>();
 
-        internal void Init(int port, String server, Main linkToMain)
+        internal void Init(int port, String server, Main linkToMain, SecureSocketOptions secureSocketOptions)
         {
             this.linkToMain = linkToMain;
             client = new SmtpClient();
-            client.Connect(server, port, false);
+            client.Connect(server, port, secureSocketOptions);
             client.AuthenticationMechanisms.Remove("XOAUTH2");
         }
 


### PR DESCRIPTION
Add support for STARTTLS and SSL in the GUI.

* Add `CheckBox` control for STARTTLS with properties `Name` as `chbStartTLS`, `Text` as `Enable STARTTLS`, and set its `Location`.
* Add `CheckBox` control for SSL with properties `Name` as `chbSSL`, `Text` as `Enable SSL`, and set its `Location`.
* Update the `btnSend_Click` method to check the state of the STARTTLS and SSL checkboxes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NightHammer1000/SMTPtool/pull/2?shareId=cffefc73-2e09-4505-9924-dcb98f7e62e0).